### PR TITLE
Fix a number of compilation warnings:

### DIFF
--- a/ild/common/ILDConeMeasLayer.cc
+++ b/ild/common/ILDConeMeasLayer.cc
@@ -122,15 +122,15 @@ Bool_t ILDConeMeasLayer::IsOnSurface(const TVector3 &xx) const
     Double_t r   = xxc.Perp();
     Double_t z   = xxc.Z();
     Double_t s   = (r - GetTanA()*z) * (r + GetTanA()*z);
-    const Double_t kTol = 1.e-8;
+    const Double_t tol = 1.e-8;
 
 #if 0
     std::cout << this->TVMeasLayer::GetName() << ":" << this->GetIndex() << ":" << std::endl;
     std::cout << "s=" << s << " xx=(" << xx.X() << "," << xx.Y() << "," << xx.Z() << ")" << std::endl;
-    std::cout << "bool=" << (TMath::Abs(s) < kTol && ((xx.Z()-fZ1)*(xx.Z()-fZ2) <= 0.)) << std::endl;
+    std::cout << "bool=" << (TMath::Abs(s) < tol && ((xx.Z()-fZ1)*(xx.Z()-fZ2) <= 0.)) << std::endl;
     std::cout << "fZ1=" << fZ1 << " fZ2=" << fZ2 << std::endl;
 #endif
 
-    return (TMath::Abs(s) < kTol && ((xx.Z()-fZ1)*(xx.Z()-fZ2) <= 0.));
+    return (TMath::Abs(s) < tol && ((xx.Z()-fZ1)*(xx.Z()-fZ2) <= 0.));
 } 
 

--- a/ild/common/ILDConeMeasLayer.cc
+++ b/ild/common/ILDConeMeasLayer.cc
@@ -31,9 +31,7 @@ ILDConeMeasLayer::ILDConeMeasLayer(TMaterial &min,
                                (r2-r1)/(z2-z1),
                             0.,0.,(r2*z1-r1*z2)/(r2-r1)),
                    fZ1(z1),
-                   fR1(r1),
                    fZ2(z2),
-                   fR2(r2),
                    fsortingPolicy(SortingPolicy)
 {
 }

--- a/ild/common/ILDConeMeasLayer.h
+++ b/ild/common/ILDConeMeasLayer.h
@@ -85,9 +85,7 @@ public:
    
 private:
   Double_t fZ1;      // z of front face
-  Double_t fR1;      // r of front face
   Double_t fZ2;      // z of back end
-  Double_t fR2;      // r of back end
   Double_t fsortingPolicy; // used for sorting the layers in to out
 
   

--- a/ild/common/ILDCylinderHit.h
+++ b/ild/common/ILDCylinderHit.h
@@ -29,6 +29,8 @@ public:
   
   /** Print Debug information */
   virtual void       DebugPrint(Option_t *opt = "")         const;
+
+  using TKalMatrix::DebugPrint;
   
   
 private:

--- a/ild/common/ILDMeasurementSurfaceStoreFiller.h
+++ b/ild/common/ILDMeasurementSurfaceStoreFiller.h
@@ -18,11 +18,7 @@ class ILDMeasurementSurfaceStoreFiller : public MeasurementSurfaceStoreFiller{
   public:
 
    
-  ILDMeasurementSurfaceStoreFiller(const gear::GearMgr& gear_mgr) :
-    _nVTXLayers(0),
-    _nSITLayers(0),
-    _nFTDLayers(0),
-    _nSETLayers(0) {
+  ILDMeasurementSurfaceStoreFiller(const gear::GearMgr& gear_mgr) {
 
     this->get_gear_parameters(gear_mgr);
     
@@ -61,12 +57,6 @@ class ILDMeasurementSurfaceStoreFiller : public MeasurementSurfaceStoreFiller{
   
   /** the strip angles for every layer and sensor */
   std::vector< std::vector< double > > _FTDStripAngles;
-  
-  unsigned _nVTXLayers;
-  unsigned _nSITLayers;
-  unsigned _nFTDLayers;
-  unsigned _nSETLayers;
-  
   
   const gear::ZPlanarParameters* _paramVXD;
   const gear::ZPlanarParameters* _paramSIT;

--- a/ild/common/ILDPlanarHit.h
+++ b/ild/common/ILDPlanarHit.h
@@ -32,6 +32,8 @@ public:
   
   /** Print Debug information */
   virtual void       DebugPrint(Option_t *opt = "")           const;
+
+  using TKalMatrix::DebugPrint;
   
   
 private:

--- a/ild/common/ILDPlanarStripHit.h
+++ b/ild/common/ILDPlanarStripHit.h
@@ -33,6 +33,8 @@ public:
   
   /** Print Debug information */
   virtual void       DebugPrint(Option_t *opt = "")           const;
+
+  using TKalMatrix::DebugPrint;
   
   
 private:

--- a/ild/common/ILDPolygonBarrelMeasLayer.cc
+++ b/ild/common/ILDPolygonBarrelMeasLayer.cc
@@ -36,7 +36,7 @@ ILDPolygonBarrelMeasLayer::ILDPolygonBarrelMeasLayer(TMaterial &min,
                                                      bool     is_active,
                                                      const Char_t    *name) : 
 ILDVMeasLayer(min, mout, Bz, CellIDs, is_active, name), _sortingPolicy(0.),
-_r0(r0),_lhalf(lhalf),_nsides(nsides),_zpos(zpos),_phi0(phi0)
+_r0(r0),_nsides(nsides)
 
 {
     

--- a/ild/common/ILDPolygonBarrelMeasLayer.h
+++ b/ild/common/ILDPolygonBarrelMeasLayer.h
@@ -120,10 +120,7 @@ private:
   double _sortingPolicy;
 
   double   _r0;       // min distance to the z-axis
-  double   _lhalf;    // half length
   int      _nsides;   
-  double   _zpos;     // z of the centre 
-  double   _phi0;     // phi of the first normal following the xaxis positive rotation
   
   double   _segment_dphi;
   double   _start_phi;

--- a/ild/common/ILDRotatedTrapMeaslayer.cc
+++ b/ild/common/ILDRotatedTrapMeaslayer.cc
@@ -31,7 +31,7 @@ ILDRotatedTrapMeaslayer::ILDRotatedTrapMeaslayer(TMaterial &min,
                                                  const Char_t    *name)
 : ILDVMeasLayer(min, mout, Bz, is_active, CellID, name),
 TPlane(center, normal),
-_sortingPolicy(SortingPolicy), _innerBaseLength(innerBaseLength), _outerBaseLength(outerBaseLength), _halfPetal(half_petal)
+_sortingPolicy(SortingPolicy), _outerBaseLength(outerBaseLength), _halfPetal(half_petal)
 {
   
   if( GetXc().Z() >= 0 ) {

--- a/ild/common/ILDRotatedTrapMeaslayer.h
+++ b/ild/common/ILDRotatedTrapMeaslayer.h
@@ -83,7 +83,6 @@ private:
   Double_t _signZ ;
   Double_t _innerR ;
   Double_t _outerR ;
-  Double_t _innerBaseLength ;
   Double_t _outerBaseLength ;
   Double_t _cosPhi ;  //** cos of the azimuthal angle of the petal 
   Double_t _sinPhi ;  //** sin of the azimuthal angle of the petal 

--- a/ild/ftd/ILDFTDKalDetector.cc
+++ b/ild/ftd/ILDFTDKalDetector.cc
@@ -390,7 +390,9 @@ void ILDFTDKalDetector::setupGearGeom( const gear::GearMgr& gearMgr ){
   //           which if traversed in the reverse direction to the next boundary then the track be propagated through carbon
   //           for a significant distance 
   
+#ifndef NDEBUG
   double eps = 1.0e-08;
+#endif
   
   for(int disk=0; disk< _nDisks; ++disk){
     
@@ -480,6 +482,7 @@ void ILDFTDKalDetector::setupGearGeom( const gear::GearMgr& gearMgr ){
     
     // there should be no gap between support and sensitive
     
+#ifndef NDEBUG
     for( int iPetal=0; iPetal< _FTDgeo[disk].nPetals; iPetal++){
       
       
@@ -491,6 +494,7 @@ void ILDFTDKalDetector::setupGearGeom( const gear::GearMgr& gearMgr ){
       assert( fabs( endSensitive- endSupport ) < eps ); 
       
     }
+#endif
     
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     

--- a/ild/support/ILDSupportKalDetector.cc
+++ b/ild/support/ILDSupportKalDetector.cc
@@ -76,10 +76,10 @@ TVKalDetector(10)
     
     
     //SJA:FIXME: HERE WE NEED TO MAKE SURE THAT THE BEAM PIPE IS NEVER DECREASING IN RADII OTHERWISE THE SORTING GOES WRONG
-    if ( rInnerStart < rInnerStart_last ) rInnerStart = rInnerStart_last; rInnerStart_last = rInnerStart;
-    if ( rInnerEnd   < rInnerEnd_last   ) rInnerEnd   = rInnerEnd_last  ; rInnerEnd_last   = rInnerEnd;
-    if ( rOuterStart < rOuterStart_last ) rOuterStart = rOuterStart_last; rOuterStart_last = rOuterStart;
-    if ( rOuterEnd   < rOuterEnd_last   ) rOuterEnd   = rOuterEnd_last;   rOuterEnd_last   = rOuterEnd;
+    rInnerStart = std::max (rInnerStart, rInnerStart_last); rInnerStart_last = rInnerStart;
+    rInnerEnd   = std::max (rInnerEnd, rInnerEnd_last); rInnerEnd_last   = rInnerEnd;
+    rOuterStart = std::max (rOuterStart, rOuterStart_last); rOuterStart_last = rOuterStart;
+    rOuterEnd   = std::max (rOuterEnd, rOuterEnd_last);   rOuterEnd_last   = rOuterEnd;
     
     
     std::stringstream sname;

--- a/lctpc/gearTPC/GearTPCCylinderHit.h
+++ b/lctpc/gearTPC/GearTPCCylinderHit.h
@@ -48,6 +48,8 @@ public:
   /** Print some debug output to std err.
    */
   virtual void       DebugPrint(Option_t *opt = "")          const;
+
+  using TKalMatrix::DebugPrint;
 };
 
 }//namespace kaldet

--- a/lctpc/gearTPC/GearTPCMeasLayer.h
+++ b/lctpc/gearTPC/GearTPCMeasLayer.h
@@ -77,6 +77,8 @@ namespace kaldet
      */
     virtual TKalMatrix XvToMv    (const TVector3   &xv)   const = 0;
 
+    using TVMeasLayer::XvToMv;
+
     /**
      * Get the z-depenent resolution in the readout plane 
      * (usually x or r\f$\phi\f$).


### PR DESCRIPTION
 - Avoid local variables with the same name as a class member.
 - Fix for variables that are unused when compiling with NDEBUG.
 - Fix some warnings about misleading indentation.
 - Fix warnings about unused variables
 - Fix warnings about hidden functions


BEGINRELEASENOTES
- Fix warnings seen with current compilers.

ENDRELEASENOTES