### PR TITLE
Bump the minimum version of CMake to 3.10, to be able to compile with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ######################################################
 # cmake file for building KalDet libraries
 # @author Jan Engels, DESY
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)
 ######################################################
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the minimum version of CMake to 3.10, to be able to compile with CMake 4.0

ENDRELEASENOTES
  
See https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features