### PR TITLE
Add missing definitions in lctpc/gearTPC/LinkDef.h

### DIFF
--- a/lctpc/gearTPC/LinkDef.h
+++ b/lctpc/gearTPC/LinkDef.h
@@ -4,13 +4,13 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class EXTPCHit+;
-#pragma link C++ class EXTPCKalDetector+;
+//#pragma link C++ class EXTPCHit+;
+//#pragma link C++ class EXTPCKalDetector+;
 #pragma link C++ class EXTPCMeasLayer+;
 #pragma link C++ class kaldet::GearTPCHit+;
-#pragma link C++ class kaldet::GearTPCCylinderHit+;
-#pragma link C++ class kaldet::GearTPCCylinderMeasLayer+;
-#pragma link C++ class kaldet::GearTPCKalDetector+;
+//#pragma link C++ class kaldet::GearTPCCylinderHit+;
+//#pragma link C++ class kaldet::GearTPCCylinderMeasLayer+;
+//#pragma link C++ class kaldet::GearTPCKalDetector+;
 #pragma link C++ class kaldet::GearTPCMeasLayer+;
 
 #endif

--- a/lctpc/gearTPC/LinkDef.h
+++ b/lctpc/gearTPC/LinkDef.h
@@ -4,5 +4,13 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class EXTPCHit+;
+#pragma link C++ class EXTPCKalDetector+;
+#pragma link C++ class EXTPCMeasLayer+;
+#pragma link C++ class kaldet::GearTPCHit+;
+#pragma link C++ class kaldet::GearTPCCylinderHit+;
+#pragma link C++ class kaldet::GearTPCCylinderMeasLayer+;
+#pragma link C++ class kaldet::GearTPCKalDetector+;
+#pragma link C++ class kaldet::GearTPCMeasLayer+;
 
 #endif


### PR DESCRIPTION
BEGINRELEASENOTES
- Add missing definitions in lctpc/gearTPC/LinkDef.h

ENDRELEASENOTES

These seem to be needed with ROOT 6.40, otherwise the following error will be found:

```
Error: No selection rules specified and creation of C++ module not requested: did you forget to specify a selection file or to request the creation of a C++ module?
```