### PR TITLE
Do not generate a LibDeps.cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,5 +142,5 @@ DISPLAY_STD_VARIABLES()
 
 
 # generate and install following configuration files
-GENERATE_PACKAGE_CONFIGURATION_FILES( KalDetConfig.cmake KalDetConfigVersion.cmake KalDetLibDeps.cmake )
+GENERATE_PACKAGE_CONFIGURATION_FILES( KalDetConfig.cmake KalDetConfigVersion.cmake)
 

--- a/cmake/KalDetConfig.cmake.in
+++ b/cmake/KalDetConfig.cmake.in
@@ -54,15 +54,6 @@ INCLUDE( "@ILCSOFT_CMAKE_MODULES_ROOT@/MacroCheckPackageLibs.cmake" )
 CHECK_PACKAGE_LIBS( KalDet KalDet )
 
 
-
-
-# ---------- libraries dependencies -------------------------------------------
-# this sets KalDet_${COMPONENT}_LIB_DEPENDS variables
-INCLUDE( "${KalDet_ROOT}/lib/cmake/KalDetLibDeps.cmake" )
- 
-
-
-
 # ---------- final checking ---------------------------------------------------
 INCLUDE( FindPackageHandleStandardArgs )
 # set KALDET_FOUND to TRUE if all listed variables are TRUE and not empty


### PR DESCRIPTION
BEGINRELEASENOTES
- Do not generate a LibDeps.cmake file

ENDRELEASENOTES

Since https://github.com/iLCSoft/KalDet/pull/4, there is this error:

```
CMake Error at /cvmfs/sft-nightlies.cern.ch/lcg/latest/ilcutil/HEAD-ee050/x86_64-el9-gcc14-opt/cmakemodules/MacroGeneratePackageConfigFiles.cmake:37 (EXPORT_LIBRARY_DEPENDENCIES):
  The export_library_dependencies command should not be called; see CMP0033.
Call Stack (most recent call first):
  CMakeLists.txt:145 (GENERATE_PACKAGE_CONFIGURATION_FILES)
```

It seems the LibDeps.cmake file is not needed and downstream packages can be built without it, so I just removed it; other LCSoft packages do not generate this file (otherwise they wouldn't work).